### PR TITLE
docs(pinecone): add initial Cursor Rules and testing instructions

### DIFF
--- a/.cursor/rules/01-project-overview.mdc
+++ b/.cursor/rules/01-project-overview.mdc
@@ -1,0 +1,28 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pinecone Haskell Library
+
+This is a Haskell binding to the Pinecone vector database API using `servant` for type-safe HTTP client generation.
+
+## Key Files
+
+- [src/Pinecone.hs](mdc:src/Pinecone.hs) - Main entry point that re-exports functionality from other modules
+- [pinecone-example/Main.hs](mdc:pinecone-example/Main.hs) - Example implementation showing basic usage
+
+## Project Structure
+
+The codebase follows a modular structure:
+
+- `src/Pinecone.hs` - Main module that exports all functionality
+- `src/Pinecone/` directory - Contains specialized modules for different Pinecone API features
+- `pinecone-example/` - Example usage of the library
+- `tasty/` - Test suite
+
+## Key Concepts
+
+- `ControlMethods` - Methods for managing Pinecone indexes (create, delete, etc.)
+- `DataMethods` - Methods for working with vector data (upsert, search, etc.)
+- The API is split into control plane (index management) and data plane (vector operations)

--- a/.cursor/rules/02-api-structure.mdc
+++ b/.cursor/rules/02-api-structure.mdc
@@ -1,0 +1,40 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pinecone API Structure
+
+The Pinecone API is split into two main parts:
+
+## Control Plane API
+
+Located in [src/Pinecone/Indexes.hs](mdc:src/Pinecone/Indexes.hs), this handles index management functions:
+
+- Creating indexes
+- Listing indexes
+- Configuring indexes
+- Deleting indexes
+
+## Data Plane API
+
+This is spread across multiple modules:
+
+- [src/Pinecone/Vectors.hs](mdc:src/Pinecone/Vectors.hs) - Vector operations (upsert, update, delete)
+- [src/Pinecone/Search.hs](mdc:src/Pinecone/Search.hs) - Vector search operations
+- [src/Pinecone/Imports.hs](mdc:src/Pinecone/Imports.hs) - Bulk import operations
+
+## Additional Features
+
+- [src/Pinecone/Backups.hs](mdc:src/Pinecone/Backups.hs) - Collection management
+- [src/Pinecone/Embed.hs](mdc:src/Pinecone/Embed.hs) - Text embedding generation
+- [src/Pinecone/Rerank.hs](mdc:src/Pinecone/Rerank.hs) - Results reranking
+
+## Usage Pattern
+
+1. Create a `ClientEnv` for the control plane using `getClientEnv`
+2. Make `ControlMethods` using `makeControlMethods`
+3. Create or access an index
+4. Create a `ClientEnv` for the data plane using the index host
+5. Make `DataMethods` using `makeDataMethods`
+6. Perform vector operations

--- a/.cursor/rules/03-usage-examples.mdc
+++ b/.cursor/rules/03-usage-examples.mdc
@@ -1,0 +1,54 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pinecone Usage Examples
+
+## Basic Setup
+
+The following pattern is used to set up a client for the Pinecone API:
+
+```haskell
+-- Set up control plane client
+controlEnv <- getClientEnv "https://api.pinecone.io"
+key <- Environment.getEnv "PINECONE_KEY"
+let token = Text.pack key
+let ControlMethods{..} = makeControlMethods controlEnv token
+
+-- Set up data plane client (after creating/getting an index)
+dataEnv <- getClientEnv host  -- host from IndexModel
+let DataMethods{..} = makeDataMethods dataEnv token
+```
+
+## Creating an Index with Embedding
+
+```haskell
+createIndexWithEmbedding _CreateIndexWithEmbedding
+    { name = "my-index"
+    , cloud = AWS
+    , region = "us-east-1"
+    , embed = EmbedRequest
+        { model = "llama-text-embed-v2"
+        , metric = Nothing
+        , read_parameters = Nothing
+        , write_parameters = Nothing
+        }
+    }
+```
+
+## Upserting and Searching
+
+```haskell
+-- Upserting text (which gets automatically embedded)
+upsertText "namespace" _Record{ id = "doc1", text = "Document content" }
+
+-- Searching with text query
+Hits{ hits } <- searchWithText "namespace" SearchWithText
+    { query = _Query{ top_k = 5, input = Just "search query" }
+    , fields = Nothing
+    , rerank = Nothing
+    }
+```
+
+See [pinecone-example/Main.hs](mdc:pinecone-example/Main.hs) for a complete working example.

--- a/.cursor/rules/04-module-overview.mdc
+++ b/.cursor/rules/04-module-overview.mdc
@@ -1,0 +1,34 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pinecone Module Overview
+
+## Main Module
+
+- [src/Pinecone.hs](mdc:src/Pinecone.hs) - Main entry point that re-exports everything
+
+## Core Functionality Modules
+
+- [src/Pinecone/Indexes.hs](mdc:src/Pinecone/Indexes.hs) - Index management (create, list, configure, delete)
+- [src/Pinecone/Vectors.hs](mdc:src/Pinecone/Vectors.hs) - Vector operations (upsert, update, delete, fetch)
+- [src/Pinecone/Search.hs](mdc:src/Pinecone/Search.hs) - Vector search operations
+
+## Additional Feature Modules
+
+- [src/Pinecone/Backups.hs](mdc:src/Pinecone/Backups.hs) - Collection management
+- [src/Pinecone/Embed.hs](mdc:src/Pinecone/Embed.hs) - Text embedding generation
+- [src/Pinecone/Imports.hs](mdc:src/Pinecone/Imports.hs) - Bulk import operations
+- [src/Pinecone/Rerank.hs](mdc:src/Pinecone/Rerank.hs) - Results reranking
+- [src/Pinecone/Metadata.hs](mdc:src/Pinecone/Metadata.hs) - Metadata filtering and handling
+
+## Utility Modules
+
+- [src/Pinecone/Prelude.hs](mdc:src/Pinecone/Prelude.hs) - Common imports and utilities
+- [src/Pinecone/Pagination.hs](mdc:src/Pinecone/Pagination.hs) - Pagination support
+
+## Example and Tests
+
+- [pinecone-example/Main.hs](mdc:pinecone-example/Main.hs) - Example application
+- [tasty/Main.hs](mdc:tasty/Main.hs) - Test suite

--- a/.cursor/rules/05-development-guidelines.mdc
+++ b/.cursor/rules/05-development-guidelines.mdc
@@ -32,7 +32,7 @@ The project enables several language extensions by default in the cabal file:
 
 ## Record Fields
 
-Many record fields begin with underscore (`_`) to avoid name clashes due to the DuplicateRecordFields extension.
+Some record fields begin with underscore (`_`) to match the Pinecone API field names (e.g. `_id` and `_score`, which have underscores in the Pinecone API).  Other record field names end with an underscore to conflicting with Haskell keywords (e.g. `data_` instead of `data`).
 
 ## Dependencies
 

--- a/.cursor/rules/05-development-guidelines.mdc
+++ b/.cursor/rules/05-development-guidelines.mdc
@@ -1,0 +1,48 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pinecone Development Guidelines
+
+## Code Style
+
+This project follows standard Haskell code conventions:
+- Use 4-space indentation
+- Use camelCase for function and variable names
+- Use PascalCase for types and constructors
+- Use snake_case for record fields to match Pinecone API naming
+
+## Language Extensions
+
+The project enables several language extensions by default in the cabal file:
+- BlockArguments
+- DataKinds
+- DeriveGeneric
+- DeriveAnyClass
+- DerivingStrategies
+- DuplicateRecordFields
+- GeneralizedNewtypeDeriving
+- NamedFieldPuns
+- OverloadedLists
+- OverloadedStrings
+- RecordWildCards
+- TypeApplications
+- TypeOperators
+
+## Record Fields
+
+Many record fields begin with underscore (`_`) to avoid name clashes due to the DuplicateRecordFields extension.
+
+## Dependencies
+
+Main external dependencies include:
+- servant/servant-client - For API type definitions and client generation
+- aeson - For JSON serialization/deserialization
+- http-client/http-client-tls - For HTTP communication
+- text - For text handling
+- vector - For vector data structures
+
+## Testing
+
+The test suite is located in the `tasty/` directory and uses the HUnit and Tasty testing frameworks.

--- a/.cursor/rules/05-development-guidelines.mdc
+++ b/.cursor/rules/05-development-guidelines.mdc
@@ -7,7 +7,7 @@ alwaysApply: false
 
 ## Code Style
 
-This project follows standard Haskell code conventions:
+This project follows standard Haskell code conventions (with the exception of record fields):
 - Use 4-space indentation
 - Use camelCase for function and variable names
 - Use PascalCase for types and constructors

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,0 +1,3 @@
+use flake
+
+export PINECONE_KEY="your-api-key-here"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# Direnv
 .direnv/
+
+# Cabal
 dist-newstyle/
+
+# Direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -81,3 +81,55 @@ main = do
 
         print (fmap _id hits) -- ["hi"]
 ```
+
+## Running Tests
+
+The test suite creates and deletes a real Pinecone index named "vectors-test" in the AWS us-east-1 region, so you'll need an active Pinecone account with appropriate permissions.
+
+### Prerequisites
+
+You need to set your Pinecone API key. You can do this in one of two ways:
+
+1. Copy the sample environment file and set your API key:
+
+   ```bash
+   cp .envrc.sample .envrc
+   # Edit .envrc and replace "your-api-key-here" with your actual Pinecone API key
+   ```
+
+2. Or set it directly as an environment variable:
+   ```bash
+   export PINECONE_KEY="your-api-key-here"
+   ```
+
+### Running tests with Nix + direnv
+
+If you're using the provided Nix development environment:
+
+1. Allow direnv to set up the environment:
+
+   ```bash
+   direnv allow
+   ```
+
+2. Run the tests using Cabal:
+   ```bash
+   cabal test
+   ```
+
+### Running tests with Nix directly
+
+Alternatively, you can use Nix directly:
+
+```bash
+nix develop
+cabal test
+```
+
+### Running tests with Cabal only
+
+If you have GHC and Cabal installed directly on your system:
+
+```bash
+cabal test
+```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You need to set your Pinecone API key. You can do this in one of two ways:
 1. Copy the sample environment file and set your API key:
 
    ```bash
-   cp .envrc.sample .envrc
+   (umask 077; cp .envrc.sample .envrc)
    # Edit .envrc and replace "your-api-key-here" with your actual Pinecone API key
    ```
 


### PR DESCRIPTION
This pull request introduces comprehensive documentation and setup improvements for the Pinecone Haskell library. Key changes include the addition of structured documentation for project overview, API structure, usage examples, module details, and development guidelines, as well as updates to the environment configuration for easier setup and testing.

### Documentation Additions:

* **Project Overview**: Added a high-level description of the library, its structure, and key concepts, including the separation between control and data plane APIs (`.cursor/rules/01-project-overview.mdc`).
* **API Structure**: Documented the split between control plane (index management) and data plane (vector operations) APIs, with links to relevant modules (`.cursor/rules/02-api-structure.mdc`).
* **Usage Examples**: Provided examples for basic setup, creating an index with embedding, and performing upserts and searches, with references to the example implementation (`.cursor/rules/03-usage-examples.mdc`).
* **Module Overview**: Detailed the purpose of each module, including core functionality, additional features, utilities, and examples/tests (`.cursor/rules/04-module-overview.mdc`).
* **Development Guidelines**: Outlined code style, language extensions, dependencies, and testing practices for contributors (`.cursor/rules/05-development-guidelines.mdc`).

### Environment Configuration:

* **Environment File Updates**: Updated `.envrc.sample` to include a placeholder for the Pinecone API key and reintroduced `use flake` for Nix setup (`.envrc.sample`, `.envrc`). [[1]](diffhunk://#diff-2abe9d8c732701468f7f9dd1eb47f6d040baa4de0708be9c5de256e3c6a2b0a4R1-R3) [[2]](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430L1)

### README Enhancements:

* **Testing Instructions**: Added detailed instructions for running tests, including prerequisites for setting the Pinecone API key and steps for using Nix, direnv, or Cabal directly (`README.md`).